### PR TITLE
feat: :sparkles: send auth token in the email validation response

### DIFF
--- a/src/components/HeroHome/HeroHomeStyles.css
+++ b/src/components/HeroHome/HeroHomeStyles.css
@@ -5,7 +5,7 @@
   max-width: 100%;
   height: 80vh;
   color: white;
-  background-image: url("img-hero-2.jpg");
+  background-image: url("/img-hero-2.jpg");
   background-repeat: no-repeat;
   background-size: cover;
   background-position: center;

--- a/src/components/LoginForm/LoginForm.jsx
+++ b/src/components/LoginForm/LoginForm.jsx
@@ -50,11 +50,15 @@ function LoginForm() {
     const response = await register(createUserData);
 
     if (response.status === 201) {
+
       Swal.fire({
         icon: 'success',
         title: 'Registration successful',
         text: 'We have sent you an email with a link to verify your account. Please check your inbox.',
       });
+
+      navigate("/");
+
     } else {
       Swal.fire({
         icon: 'error',
@@ -62,8 +66,6 @@ function LoginForm() {
         text: 'Something went wrong. Please try again.',
       });
     }
-
-    navigate("/");
   }
 
   return (

--- a/src/pages/ActivateAccount.jsx
+++ b/src/pages/ActivateAccount.jsx
@@ -1,18 +1,48 @@
 import OrangeButton from "../components/OrangeButton/OrangeButton";
 import { FaTaxi } from "react-icons/fa";
 import SingleFooter from "../components/SingleFooter/SingleFooter";
-import './ActivateAccount.css';
 import { useParams } from 'react-router-dom';
 import { activate } from "../services/auth";
+import Swal from 'sweetalert2';
+import { useNavigate } from "react-router-dom";
 
+import './ActivateAccount.css';
 
 
 function Login() {
   const { token } = useParams();
+  const navigate = useNavigate();
+
   async function onClickHandler() {
-    const loginPayload = await activate(token);
-    console.log(loginPayload);
+
+    const response = await activate(token);
+
+    if (response.status === 200) {
+
+      Swal.fire({
+        icon: 'success',
+        title: 'Registration successful',
+        text: 'Enjoy all services that we have for you, start now!',
+      });
+
+      const loginPayload = await response.json();
+
+      console.log(loginPayload);
+
+      localStorage.setItem("authToken", loginPayload.token);
+      localStorage.setItem("profile", JSON.stringify(loginPayload.profile));
+
+      navigate("/");
+
+    } else {
+      Swal.fire({
+        icon: 'error',
+        title: 'Registration failed',
+        text: 'Something went wrong. Please try again.',
+      });
+    }
   };
+
   return (
     <div className="c-activate-account">
       <div className="activate-account">

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -46,9 +46,7 @@ export async function activate (token) {
       body: JSON.stringify({token}),
     };
 
-
-
     const response = await fetch(`${BASE_URL}/auth/local/activate`, options);
 
-    return response.json();
+    return response;
 };


### PR DESCRIPTION
### Descripción
Se agrega funcionalidad para que despues de confirmar el email se reciba el token de autenticación y el usuario pase directamente al home con sus credenciales ya validadas.


### Feeling
[//]: <> (Como te sientes con este PR? la solucion que entregas como te hace sentir?)
- [X] 🤙 Solucion rapida
- [ ] 👌 Terminado y listo
- [ ] 🤞 Espero que esto funcione, por favor revisar cuidadosamente

### Cómo probar?
- Ingresar a la pagina:
 http://localhost:5173/activate-account/42f14b53b77a845b57675d9e428c5708972654b018215fadf895e314f81f49b8
- Dar click en el boton, debe tener el backend funcionando.

### Scope

- [ ] 🐞 Bugfix (non-breaking changes que resuelve un problema
- [X] 💚 Mejora (non-breaking change que agrega/modifica funcionalidad a una característica existente)
- [ ] ⚡️ Nueva característica/feature (non-breaking change que agrega una nueva característica)
- [ ] ⚠️ Breaking change (cambio que no es compatible con versiones anteriores y/o cambia la funcionalidad actual)
